### PR TITLE
Disable base64 encoding

### DIFF
--- a/lambda.js
+++ b/lambda.js
@@ -3,9 +3,9 @@ const app = require("./dist/ngx-serverless-starter/serverless/main").server;
 
 module.exports.handler = serverlessExpress({
   app,
-  binarySettings: {
-    isBinary: ({ headers }) => true,
-    contentTypes: [],
-    contentEncodings: [],
-  },
+  // binarySettings: {
+  //   isBinary: ({ headers }) => true,
+  //   contentTypes: [],
+  //   contentEncodings: [],
+  // },
 });

--- a/server.ts
+++ b/server.ts
@@ -31,6 +31,7 @@ export function app(): express.Express {
 
   // All regular routes use the Universal engine
   server.get('*', (req, res) => {
+    res.header('Content-Type', 'text/html');
     res.render(indexHtml, { req, providers: [{ provide: APP_BASE_HREF, useValue: req.baseUrl }] });
   });
 

--- a/serverless.ts
+++ b/serverless.ts
@@ -30,6 +30,7 @@ server.get('*.*', express.static(distFolder, {
 
 // All regular routes use the Universal engine
 server.get('*', (req, res) => {
+  res.header('Content-Type', 'text/html');
   res.render(indexHtml, { req, providers: [{ provide: APP_BASE_HREF, useValue: req.baseUrl }] });
 });
 


### PR DESCRIPTION
Addresses issue #8 

- Disables base64 encoding of response from Lambda.
- Sets `Content-Type` header of response to `text/html`